### PR TITLE
Properly load >10 seconds per ping configurations

### DIFF
--- a/PingTest/PingTest/MainForm.cs
+++ b/PingTest/PingTest/MainForm.cs
@@ -830,8 +830,8 @@ namespace PingTracer
 
 			txtHost.Text = hs.host;
 			txtDisplayName.Text = hs.displayName;
-			nudPingsPerSecond.Value = hs.rate;
 			selectPingsPerSecond.SelectedIndex = hs.pingsPerSecond ? 0 : 1;
+			nudPingsPerSecond.Value = hs.rate;
 			cbTraceroute.Checked = hs.doTraceRoute;
 			cbReverseDNS.Checked = hs.reverseDnsLookup;
 			cbAlwaysShowServerNames.Checked = hs.drawServerNames;


### PR DESCRIPTION
Steps to reproduce problem: Set >10 seconds per ping, close and start application again. You'll get a `System.ArgumentOutOfRangeException`.

Reason: XML value "rate" is loaded into `nudPingsPerSecond.Value` when it is still in default "pings per second" mode (where `nudPingsPerSecond.Maximum = 10`). Mode is loaded only in the next step.

Fix: Load mode before loading rate/value.