### PR TITLE
Add Phase 1 core data model: Storage layer + xUnit test project

### DIFF
--- a/PingTest/PingTest/Storage/ChunkedSeriesBuffer.cs
+++ b/PingTest/PingTest/Storage/ChunkedSeriesBuffer.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+
+namespace PingTracer.Storage
+{
+	/// <summary>
+	/// Append-only buffer backed by fixed-size chunks. Supports O(1) append,
+	/// O(1) random access by RecordHandle, O(log n) binary search, and efficient
+	/// front-pruning by dropping whole leading chunks.
+	///
+	/// Not thread-safe; callers are responsible for synchronization.
+	/// </summary>
+	public class ChunkedSeriesBuffer<T> where T : struct
+	{
+		private const int DefaultChunkSize = 4096;
+
+		private readonly int _chunkSize;
+		private readonly List<T[]> _chunks = new List<T[]>();
+
+		// Logical chunk index of _chunks[0]. Increments each time we drop a leading chunk.
+		private int _firstLogicalChunkIndex = 0;
+
+		// Number of items used in _chunks[^1]. Valid only when _chunks.Count > 0.
+		private int _lastChunkUsedCount = 0;
+
+		/// <summary>Total records ever appended. Never decrements.</summary>
+		public long TotalCount { get; private set; } = 0;
+
+		/// <summary>Records currently stored (decrements on prune).</summary>
+		public long ActiveCount { get; private set; } = 0;
+
+		/// <summary>Number of live chunks.</summary>
+		public int ChunkCount => _chunks.Count;
+
+		/// <summary>Logical index of the first live chunk.</summary>
+		public int FirstLogicalChunkIndex => _firstLogicalChunkIndex;
+
+		public ChunkedSeriesBuffer(int chunkSize = DefaultChunkSize)
+		{
+			if (chunkSize < 1) throw new ArgumentOutOfRangeException(nameof(chunkSize));
+			_chunkSize = chunkSize;
+		}
+
+		/// <summary>Appends an item and returns its stable handle.</summary>
+		public RecordHandle Append(T item)
+		{
+			if (_chunks.Count == 0 || _lastChunkUsedCount == _chunkSize)
+			{
+				_chunks.Add(new T[_chunkSize]);
+				_lastChunkUsedCount = 0;
+			}
+
+			int listIndex = _chunks.Count - 1;
+			int slotIndex = _lastChunkUsedCount;
+			_chunks[listIndex][slotIndex] = item;
+			_lastChunkUsedCount++;
+			TotalCount++;
+			ActiveCount++;
+
+			return new RecordHandle(_firstLogicalChunkIndex + listIndex, slotIndex);
+		}
+
+		/// <summary>Returns a managed ref to the record at h for in-place update.</summary>
+		public ref T GetRef(RecordHandle h)
+		{
+			int listIndex = h.ChunkIndex - _firstLogicalChunkIndex;
+			if ((uint)listIndex >= (uint)_chunks.Count)
+				throw new InvalidOperationException($"Chunk {h.ChunkIndex} has been pruned or is out of range (first={_firstLogicalChunkIndex}, count={_chunks.Count}).");
+			ValidateSlot(listIndex, h.SlotIndex);
+			return ref _chunks[listIndex][h.SlotIndex];
+		}
+
+		/// <summary>Returns a value copy of the record at h.</summary>
+		public T Get(RecordHandle h) => GetRef(h);
+
+		private void ValidateSlot(int listIndex, int slotIndex)
+		{
+			int maxSlot = (listIndex == _chunks.Count - 1) ? _lastChunkUsedCount - 1 : _chunkSize - 1;
+			if ((uint)slotIndex > (uint)maxSlot)
+				throw new ArgumentOutOfRangeException(nameof(slotIndex), $"Slot {slotIndex} is out of range [0,{maxSlot}].");
+		}
+
+		private int GetChunkUsedCount(int listIndex)
+		{
+			return listIndex == _chunks.Count - 1 ? _lastChunkUsedCount : _chunkSize;
+		}
+
+		/// <summary>
+		/// Drops all chunks with logical index less than keepFromLogicalChunkIndex.
+		/// The last chunk is never dropped regardless of the parameter.
+		/// </summary>
+		public void PruneChunksOlderThan(int keepFromLogicalChunkIndex)
+		{
+			// Always preserve at least 1 chunk
+			int maxCanDrop = _chunks.Count - 1;
+			if (maxCanDrop <= 0) return;
+
+			int wantToDrop = keepFromLogicalChunkIndex - _firstLogicalChunkIndex;
+			if (wantToDrop <= 0) return;
+
+			int countToDrop = Math.Min(wantToDrop, maxCanDrop);
+
+			// Non-last chunks are always full, so this is exact.
+			ActiveCount -= (long)countToDrop * _chunkSize;
+
+			_chunks.RemoveRange(0, countToDrop);
+			_firstLogicalChunkIndex += countToDrop;
+		}
+
+		/// <summary>
+		/// Enumerates records starting at (or after) the given handle.
+		/// If the handle's chunk has been pruned, enumeration starts from the first available record.
+		/// </summary>
+		public IEnumerable<(RecordHandle handle, T record)> EnumerateFrom(RecordHandle start)
+		{
+			if (_chunks.Count == 0) yield break;
+
+			int startListIndex = start.ChunkIndex - _firstLogicalChunkIndex;
+			bool pruned = startListIndex < 0;
+			if (pruned) startListIndex = 0;
+
+			for (int ci = startListIndex; ci < _chunks.Count; ci++)
+			{
+				int logicalIndex = ci + _firstLogicalChunkIndex;
+				T[] chunk = _chunks[ci];
+				int usedCount = GetChunkUsedCount(ci);
+
+				int startSlot = 0;
+				if (ci == startListIndex && !pruned)
+					startSlot = Math.Max(0, start.SlotIndex);
+
+				for (int si = startSlot; si < usedCount; si++)
+					yield return (new RecordHandle(logicalIndex, si), chunk[si]);
+			}
+		}
+
+		/// <summary>
+		/// Returns the handle of the first record where keySelector(record) >= target,
+		/// or null if all records are less than target. Requires records to be in
+		/// non-decreasing key order.
+		/// </summary>
+		public RecordHandle? LowerBound<TKey>(Func<T, TKey> keySelector, TKey target)
+			where TKey : IComparable<TKey>
+		{
+			if (_chunks.Count == 0) return null;
+
+			// Chunk-level search: find the first chunk whose last element >= target.
+			int lo = 0, hi = _chunks.Count - 1;
+
+			// Check if target is beyond all data
+			{
+				int lastListIndex = _chunks.Count - 1;
+				int lastSlot = _lastChunkUsedCount - 1;
+				if (keySelector(_chunks[lastListIndex][lastSlot]).CompareTo(target) < 0)
+					return null;
+			}
+
+			while (lo < hi)
+			{
+				int mid = (lo + hi) / 2;
+				int midUsed = GetChunkUsedCount(mid);
+				int cmp = keySelector(_chunks[mid][midUsed - 1]).CompareTo(target);
+				if (cmp < 0)
+					lo = mid + 1;
+				else
+					hi = mid;
+			}
+
+			// lo is the first chunk whose last element >= target; binary search within it.
+			T[] searchChunk = _chunks[lo];
+			int chunkUsed = GetChunkUsedCount(lo);
+
+			int cLo = 0, cHi = chunkUsed - 1;
+			while (cLo <= cHi)
+			{
+				int mid = (cLo + cHi) / 2;
+				if (keySelector(searchChunk[mid]).CompareTo(target) < 0)
+					cLo = mid + 1;
+				else
+					cHi = mid - 1;
+			}
+
+			if (cLo < chunkUsed)
+				return new RecordHandle(lo + _firstLogicalChunkIndex, cLo);
+
+			// All elements in this chunk are < target — try next chunk.
+			if (lo + 1 < _chunks.Count)
+				return new RecordHandle(lo + 1 + _firstLogicalChunkIndex, 0);
+
+			return null;
+		}
+	}
+}

--- a/PingTest/PingTest/Storage/HopHistory.cs
+++ b/PingTest/PingTest/Storage/HopHistory.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace PingTracer.Storage
+{
+	/// <summary>
+	/// Chronological list of all HopTimeSeries entries for a single hop position.
+	/// New series are appended when the responding address changes; closed series
+	/// are never reopened. Thread safety: callers must lock on this instance when
+	/// accessing Series in a multi-threaded context.
+	/// </summary>
+	public class HopHistory
+	{
+		public readonly byte HopNumber;
+
+		public readonly List<HopTimeSeries> Series = new List<HopTimeSeries>();
+
+		/// <summary>
+		/// The currently active series for this hop, or null if none is active.
+		/// </summary>
+		public HopTimeSeries ActiveSeries =>
+			Series.Count > 0 && Series[Series.Count - 1].IsActive
+				? Series[Series.Count - 1]
+				: null;
+
+		public HopHistory(byte hopNumber)
+		{
+			HopNumber = hopNumber;
+		}
+	}
+}

--- a/PingTest/PingTest/Storage/HopTimeSeries.cs
+++ b/PingTest/PingTest/Storage/HopTimeSeries.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace PingTracer.Storage
+{
+	/// <summary>
+	/// Time-series ping data for a specific (hop number, IP address) pair
+	/// during a contiguous monitoring period.
+	/// </summary>
+	public class HopTimeSeries
+	{
+		private readonly ChunkedSeriesBuffer<PingRecord> _records = new ChunkedSeriesBuffer<PingRecord>();
+		private DateTime _lastRecordedTimestampUtc;
+		private readonly object _writeLock = new object();
+
+		public readonly byte HopNumber;
+		public readonly IPAddress Address;
+		public readonly DateTime StartTimeUtc;
+
+		public string Hostname { get; private set; }
+		public DateTime? EndTimeUtc { get; set; }
+		public bool IsActive => EndTimeUtc == null;
+		public long RecordCount => _records.ActiveCount;
+
+		public event Action<HopTimeSeries> HostnameUpdated;
+
+		public HopTimeSeries(byte hopNumber, IPAddress address, DateTime startTimeUtc, bool startDnsLookup = false)
+		{
+			HopNumber = hopNumber;
+			Address = address ?? throw new ArgumentNullException(nameof(address));
+			StartTimeUtc = startTimeUtc;
+			_lastRecordedTimestampUtc = startTimeUtc;
+
+			if (startDnsLookup)
+				StartDnsLookup();
+		}
+
+		private void StartDnsLookup()
+		{
+			_ = Task.Run(async () =>
+			{
+				try
+				{
+					var entry = await Dns.GetHostEntryAsync(Address).ConfigureAwait(false);
+					SetHostname(entry.HostName);
+				}
+				catch { }
+			});
+		}
+
+		public void SetHostname(string hostname)
+		{
+			Hostname = hostname;
+			HostnameUpdated?.Invoke(this);
+		}
+
+		/// <summary>
+		/// Records a new ping as pending (in-flight). Returns a handle for later completion.
+		/// Clamps backward clock jumps to preserve non-decreasing timestamp order.
+		/// </summary>
+		public RecordHandle BeginPendingRecord(DateTime sentTimestampUtc)
+		{
+			lock (_writeLock)
+			{
+				if (sentTimestampUtc < _lastRecordedTimestampUtc)
+					sentTimestampUtc = _lastRecordedTimestampUtc;
+
+				_lastRecordedTimestampUtc = sentTimestampUtc;
+
+				uint relativeMs = (uint)(sentTimestampUtc - StartTimeUtc).TotalMilliseconds;
+				var record = new PingRecord { RelativeTimeMs = relativeMs, RoundTripMs = PingRecordStatus.Pending };
+				return _records.Append(record);
+			}
+		}
+
+		/// <summary>
+		/// Updates the pending record identified by handle with the actual RTT or status code.
+		/// </summary>
+		public void CompleteRecord(RecordHandle handle, ushort rttOrStatusCode)
+		{
+			lock (_writeLock)
+			{
+				ref PingRecord record = ref _records.GetRef(handle);
+				record.RoundTripMs = rttOrStatusCode;
+			}
+		}
+
+		/// <summary>
+		/// Enumerates all records in the given UTC time range (inclusive on both ends).
+		/// Pending records are included with their status code.
+		/// </summary>
+		public IEnumerable<(DateTime timestamp, ushort rtt)> QueryRange(DateTime start, DateTime end)
+		{
+			if (end < StartTimeUtc) yield break;
+			if (start > (EndTimeUtc ?? DateTime.MaxValue)) yield break;
+
+			uint startRelativeMs = start <= StartTimeUtc
+				? 0
+				: (uint)(start - StartTimeUtc).TotalMilliseconds;
+			uint endRelativeMs = (uint)Math.Max(0, (end - StartTimeUtc).TotalMilliseconds);
+
+			RecordHandle? startHandle = _records.LowerBound(r => r.RelativeTimeMs, startRelativeMs);
+			if (startHandle == null) yield break;
+
+			foreach (var (_, record) in _records.EnumerateFrom(startHandle.Value))
+			{
+				if (record.RelativeTimeMs > endRelativeMs) yield break;
+				yield return (StartTimeUtc.AddMilliseconds(record.RelativeTimeMs), record.RoundTripMs);
+			}
+		}
+
+		/// <summary>
+		/// Returns aggregated statistics for the given time range.
+		/// When record count exceeds maxPoints, results are bucketed into maxPoints buckets.
+		/// Pending records are excluded from latency statistics.
+		/// </summary>
+		public AggregateResult AggregateRange(DateTime start, DateTime end, int maxPoints)
+		{
+			if (maxPoints < 1) throw new ArgumentOutOfRangeException(nameof(maxPoints));
+
+			var raw = new List<(DateTime timestamp, ushort rtt)>(capacity: 256);
+			foreach (var item in QueryRange(start, end))
+				raw.Add(item);
+
+			if (raw.Count == 0)
+				return new AggregateResult { Series = this, Points = Array.Empty<AggregatedPoint>() };
+
+			if (raw.Count <= maxPoints)
+				return new AggregateResult { Series = this, Points = BuildSinglePointBuckets(raw) };
+
+			return new AggregateResult { Series = this, Points = BuildDownsampledBuckets(raw, start, end, maxPoints) };
+		}
+
+		private static AggregatedPoint[] BuildSinglePointBuckets(List<(DateTime timestamp, ushort rtt)> raw)
+		{
+			var pts = new AggregatedPoint[raw.Count];
+			for (int i = 0; i < raw.Count; i++)
+			{
+				var (ts, rtt) = raw[i];
+				pts[i].TimestampUtc = ts;
+				pts[i].SampleCount = 1;
+				if (rtt == PingRecordStatus.Timeout)
+				{
+					pts[i].PacketLossPercent = 100.0;
+				}
+				else if (rtt != PingRecordStatus.Pending)
+				{
+					pts[i].AvgRtt = rtt;
+					pts[i].MinRtt = rtt;
+					pts[i].MaxRtt = rtt;
+				}
+			}
+			return pts;
+		}
+
+		private static AggregatedPoint[] BuildDownsampledBuckets(
+			List<(DateTime timestamp, ushort rtt)> raw,
+			DateTime start, DateTime end, int maxPoints)
+		{
+			double totalMs = (end - start).TotalMilliseconds;
+			double bucketMs = totalMs / maxPoints;
+
+			var pts = new AggregatedPoint[maxPoints];
+			var sumRtt = new double[maxPoints];
+			var successCount = new int[maxPoints];
+			var timeoutCount = new int[maxPoints];
+			var hasData = new bool[maxPoints];
+
+			for (int i = 0; i < maxPoints; i++)
+				pts[i].TimestampUtc = start.AddMilliseconds((i + 0.5) * bucketMs);
+
+			foreach (var (ts, rtt) in raw)
+			{
+				if (rtt == PingRecordStatus.Pending) continue;
+
+				int bi = Math.Min(maxPoints - 1, (int)((ts - start).TotalMilliseconds / bucketMs));
+				pts[bi].SampleCount++;
+				hasData[bi] = true;
+
+				if (rtt == PingRecordStatus.Timeout)
+				{
+					timeoutCount[bi]++;
+				}
+				else
+				{
+					double v = rtt;
+					sumRtt[bi] += v;
+					successCount[bi]++;
+					if (successCount[bi] == 1 || v < pts[bi].MinRtt) pts[bi].MinRtt = v;
+					if (v > pts[bi].MaxRtt) pts[bi].MaxRtt = v;
+				}
+			}
+
+			for (int i = 0; i < maxPoints; i++)
+			{
+				if (!hasData[i]) continue;
+				int total = pts[i].SampleCount;
+				if (total > 0)
+					pts[i].PacketLossPercent = 100.0 * timeoutCount[i] / total;
+				if (successCount[i] > 0)
+					pts[i].AvgRtt = sumRtt[i] / successCount[i];
+			}
+
+			return pts;
+		}
+
+		/// <summary>
+		/// Drops whole leading chunks whose records all predate the cutoff.
+		/// Keeps at least the last chunk.
+		/// </summary>
+		public void PruneOlderThan(DateTime cutoff)
+		{
+			if (cutoff <= StartTimeUtc) return;
+
+			uint cutoffRelativeMs = (uint)(cutoff - StartTimeUtc).TotalMilliseconds;
+
+			RecordHandle? keepFrom = _records.LowerBound(r => r.RelativeTimeMs, cutoffRelativeMs);
+			int keepFromChunkIndex;
+			if (keepFrom == null)
+			{
+				// All records predate cutoff; keep the last chunk.
+				keepFromChunkIndex = _records.FirstLogicalChunkIndex + _records.ChunkCount - 1;
+			}
+			else
+			{
+				keepFromChunkIndex = keepFrom.Value.ChunkIndex;
+			}
+
+			_records.PruneChunksOlderThan(keepFromChunkIndex);
+		}
+	}
+
+	public class AggregateResult
+	{
+		public HopTimeSeries Series;
+		public AggregatedPoint[] Points;
+	}
+
+	public struct AggregatedPoint
+	{
+		public DateTime TimestampUtc;
+		public double AvgRtt;
+		public double MinRtt;
+		public double MaxRtt;
+		public double PacketLossPercent;
+		public int SampleCount;
+	}
+}

--- a/PingTest/PingTest/Storage/MonitoringSession.cs
+++ b/PingTest/PingTest/Storage/MonitoringSession.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using PingTracer.TraceRoute;
+
+namespace PingTracer.Storage
+{
+	/// <summary>
+	/// Top-level container for all data collected while monitoring a target.
+	/// HopData is a fixed 255-element array initialized at construction; the array
+	/// never changes, so callers can access a slot by index without locking.
+	/// Modifications to HopHistory.Series must be guarded by locking on the HopHistory instance.
+	/// </summary>
+	public class MonitoringSession
+	{
+		private readonly object _sessionLock = new object();
+
+		public readonly IPAddress TargetAddress;
+		public readonly string DisplayName;
+		public readonly DateTime StartTimeUtc;
+
+		/// <summary>255 hop slots, 0-based. HopData[0] = TTL 1, etc.</summary>
+		public readonly HopHistory[] HopData;
+
+		public readonly List<RouteSnapshot> RouteHistory = new List<RouteSnapshot>();
+
+		public RouteSnapshot CurrentRoute { get; private set; }
+
+		public event Action<RouteSnapshot, RouteSnapshot> RouteChanged;
+		public event Action<DateTime> TraceResultRecorded;
+
+		public MonitoringSession(IPAddress targetAddress, string displayName)
+		{
+			TargetAddress = targetAddress ?? throw new ArgumentNullException(nameof(targetAddress));
+			DisplayName = displayName ?? string.Empty;
+			StartTimeUtc = DateTime.UtcNow;
+
+			HopData = new HopHistory[255];
+			for (int i = 0; i < 255; i++)
+				HopData[i] = new HopHistory((byte)i);
+		}
+
+		/// <summary>
+		/// Processes one completed traceroute cycle: updates HopTimeSeries entries,
+		/// builds a new RouteSnapshot, fires RouteChanged if the topology changed.
+		/// </summary>
+		public void RecordTraceResult(TraceRouteHostResult[] results, DateTime timestamp)
+		{
+			if (results == null || results.Length == 0)
+				return;
+
+			// Index results by TTL for O(1) lookup
+			var byTtl = new Dictionary<byte, TraceRouteHostResult>(results.Length);
+			byte maxTtl = 0;
+			foreach (var r in results)
+			{
+				byTtl[r.ttl] = r;
+				if (r.ttl > maxTtl) maxTtl = r.ttl;
+			}
+
+			var snapshotHops = new HopTimeSeries[maxTtl];
+
+			for (byte ttl = 1; ttl <= maxTtl; ttl++)
+			{
+				int hopIndex = ttl - 1;
+				byTtl.TryGetValue(ttl, out var result);
+
+				bool responded = result != null
+					&& result.success
+					&& result.replyFrom != null
+					&& !result.replyFrom.Equals(IPAddress.Any);
+
+				HopHistory history = HopData[hopIndex];
+
+				lock (history)
+				{
+					if (responded)
+					{
+						HopTimeSeries active = history.ActiveSeries;
+						if (active != null && active.Address.Equals(result.replyFrom))
+						{
+							// Same address — reuse.
+							snapshotHops[hopIndex] = active;
+						}
+						else
+						{
+							// New address (or first appearance). Close any active series.
+							if (active != null)
+								active.EndTimeUtc = timestamp;
+
+							var newSeries = new HopTimeSeries((byte)hopIndex, result.replyFrom, timestamp, startDnsLookup: true);
+							history.Series.Add(newSeries);
+							snapshotHops[hopIndex] = newSeries;
+						}
+					}
+					else
+					{
+						// Hop didn't respond — close any previously active series.
+						HopTimeSeries active = history.ActiveSeries;
+						if (active != null)
+							active.EndTimeUtc = timestamp;
+
+						snapshotHops[hopIndex] = null;
+					}
+				}
+			}
+
+			var newSnapshot = new RouteSnapshot(timestamp, snapshotHops);
+			RouteSnapshot oldRoute;
+
+			lock (_sessionLock)
+			{
+				oldRoute = CurrentRoute;
+				RouteHistory.Add(newSnapshot);
+				CurrentRoute = newSnapshot;
+			}
+
+			// Fire events outside all locks to prevent deadlocks.
+			var changes = newSnapshot.DiffFrom(oldRoute);
+			if (changes.Count > 0)
+				RouteChanged?.Invoke(oldRoute, newSnapshot);
+
+			TraceResultRecorded?.Invoke(timestamp);
+		}
+
+		/// <summary>Returns all currently active HopTimeSeries across all hop positions.</summary>
+		public IEnumerable<HopTimeSeries> GetActiveHops()
+		{
+			foreach (HopHistory history in HopData)
+			{
+				HopTimeSeries active;
+				lock (history)
+					active = history.ActiveSeries;
+
+				if (active != null)
+					yield return active;
+			}
+		}
+
+		/// <summary>
+		/// Prunes all HopTimeSeries older than maxAge and removes any fully-emptied
+		/// inactive series from HopHistory.Series. Trims RouteHistory but always
+		/// retains the single most-recent snapshot that predates the cutoff.
+		/// </summary>
+		public void PruneOlderThan(TimeSpan maxAge)
+		{
+			DateTime cutoff = DateTime.UtcNow - maxAge;
+
+			foreach (HopHistory history in HopData)
+			{
+				lock (history)
+				{
+					for (int j = history.Series.Count - 1; j >= 0; j--)
+					{
+						HopTimeSeries series = history.Series[j];
+						series.PruneOlderThan(cutoff);
+
+						if (series.RecordCount == 0 && !series.IsActive)
+							history.Series.RemoveAt(j);
+					}
+				}
+			}
+
+			lock (_sessionLock)
+			{
+				// Find the last entry strictly before the cutoff.
+				int lastBeforeCutoff = -1;
+				for (int i = 0; i < RouteHistory.Count; i++)
+				{
+					if (RouteHistory[i].TimestampUtc < cutoff)
+						lastBeforeCutoff = i;
+					else
+						break;
+				}
+
+				// Remove all entries before lastBeforeCutoff (keep it as the anchor).
+				if (lastBeforeCutoff > 0)
+					RouteHistory.RemoveRange(0, lastBeforeCutoff);
+			}
+		}
+
+		/// <summary>
+		/// Returns all HopTimeSeries whose time ranges overlap [start, end].
+		/// </summary>
+		public IEnumerable<HopTimeSeries> GetAggregatedData(DateTime start, DateTime end, int maxPointsPerHop)
+		{
+			foreach (HopHistory history in HopData)
+			{
+				List<HopTimeSeries> snapshot;
+				lock (history)
+					snapshot = new List<HopTimeSeries>(history.Series);
+
+				foreach (HopTimeSeries series in snapshot)
+				{
+					DateTime seriesEnd = series.EndTimeUtc ?? DateTime.MaxValue;
+					bool overlaps = series.StartTimeUtc <= end && seriesEnd >= start;
+					if (overlaps)
+						yield return series;
+				}
+			}
+		}
+	}
+}

--- a/PingTest/PingTest/Storage/PingRecord.cs
+++ b/PingTest/PingTest/Storage/PingRecord.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+
+namespace PingTracer.Storage
+{
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	public struct PingRecord
+	{
+		public uint RelativeTimeMs;
+		public ushort RoundTripMs;
+	}
+
+	public static class PingRecordStatus
+	{
+		public const ushort Pending = 0xFFFE;
+		public const ushort Timeout = 0xFFFF;
+
+		public static bool IsSuccess(ushort rtt) => rtt <= 65533;
+	}
+}

--- a/PingTest/PingTest/Storage/RecordHandle.cs
+++ b/PingTest/PingTest/Storage/RecordHandle.cs
@@ -1,0 +1,20 @@
+namespace PingTracer.Storage
+{
+	/// <summary>
+	/// Identifies the exact position of a PingRecord in a ChunkedSeriesBuffer.
+	/// Logical chunk indices are stable across front-pruning operations.
+	/// </summary>
+	public readonly struct RecordHandle
+	{
+		public readonly int ChunkIndex;
+		public readonly int SlotIndex;
+
+		public RecordHandle(int chunkIndex, int slotIndex)
+		{
+			ChunkIndex = chunkIndex;
+			SlotIndex = slotIndex;
+		}
+
+		public override string ToString() => $"[chunk={ChunkIndex}, slot={SlotIndex}]";
+	}
+}

--- a/PingTest/PingTest/Storage/RouteSnapshot.cs
+++ b/PingTest/PingTest/Storage/RouteSnapshot.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace PingTracer.Storage
+{
+	/// <summary>
+	/// Represents the known route topology at a point in time.
+	/// Hops is 0-indexed; a null entry means no response at that hop position.
+	/// </summary>
+	public class RouteSnapshot
+	{
+		public readonly DateTime TimestampUtc;
+
+		/// <summary>
+		/// 0-based hop entries. null means no response at that position.
+		/// Length reflects the highest TTL included in the snapshot.
+		/// </summary>
+		public readonly HopTimeSeries[] Hops;
+
+		public RouteSnapshot(DateTime timestampUtc, HopTimeSeries[] hops)
+		{
+			TimestampUtc = timestampUtc;
+			Hops = hops ?? throw new ArgumentNullException(nameof(hops));
+		}
+
+		/// <summary>
+		/// Computes the set of hop-address changes between this snapshot and a previous one.
+		/// Returns an empty list when the routes are identical.
+		/// </summary>
+		public IReadOnlyList<RouteChange> DiffFrom(RouteSnapshot previous)
+		{
+			var changes = new List<RouteChange>();
+
+			int maxLen = Math.Max(Hops.Length, previous?.Hops?.Length ?? 0);
+			for (int i = 0; i < maxLen; i++)
+			{
+				IPAddress oldAddr = previous != null && i < previous.Hops.Length ? previous.Hops[i]?.Address : null;
+				IPAddress newAddr = i < Hops.Length ? Hops[i]?.Address : null;
+
+				bool changed = oldAddr == null
+					? newAddr != null
+					: newAddr == null || !oldAddr.Equals(newAddr);
+
+				if (changed)
+					changes.Add(new RouteChange((byte)i, oldAddr, newAddr));
+			}
+
+			return changes;
+		}
+	}
+
+	public class RouteChange
+	{
+		public readonly byte HopIndex;
+		public readonly IPAddress OldAddress;
+		public readonly IPAddress NewAddress;
+
+		public RouteChange(byte hopIndex, IPAddress oldAddress, IPAddress newAddress)
+		{
+			HopIndex = hopIndex;
+			OldAddress = oldAddress;
+			NewAddress = newAddress;
+		}
+	}
+}

--- a/PingTest/PingTracer.Tests/ChunkedSeriesBufferTests.cs
+++ b/PingTest/PingTracer.Tests/ChunkedSeriesBufferTests.cs
@@ -1,0 +1,191 @@
+using System;
+using PingTracer.Storage;
+using Xunit;
+
+namespace PingTracer.Tests
+{
+	public class ChunkedSeriesBufferTests
+	{
+		[Fact]
+		public void Append_And_Get_Roundtrip()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 4);
+			var r = new PingRecord { RelativeTimeMs = 100, RoundTripMs = 42 };
+
+			var handle = buf.Append(r);
+			var got = buf.Get(handle);
+
+			Assert.Equal(100u, got.RelativeTimeMs);
+			Assert.Equal((ushort)42, got.RoundTripMs);
+			Assert.Equal(1, buf.ActiveCount);
+			Assert.Equal(1, buf.TotalCount);
+		}
+
+		[Fact]
+		public void GetRef_InPlaceUpdate_Works()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 4);
+			var handle = buf.Append(new PingRecord { RelativeTimeMs = 50, RoundTripMs = PingRecordStatus.Pending });
+
+			ref PingRecord rec = ref buf.GetRef(handle);
+			rec.RoundTripMs = 77;
+
+			Assert.Equal((ushort)77, buf.Get(handle).RoundTripMs);
+		}
+
+		[Fact]
+		public void Append_AcrossMultipleChunks()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 3);
+
+			for (int i = 0; i < 7; i++)
+				buf.Append(new PingRecord { RelativeTimeMs = (uint)i * 10, RoundTripMs = (ushort)i });
+
+			Assert.Equal(7, buf.ActiveCount);
+			Assert.Equal(3, buf.ChunkCount); // chunks: [0,1,2] [3,4,5] [6]
+
+			// Spot-check last item
+			var last = buf.Append(new PingRecord { RelativeTimeMs = 70, RoundTripMs = 99 });
+			Assert.Equal((ushort)99, buf.Get(last).RoundTripMs);
+		}
+
+		[Fact]
+		public void PruneChunksOlderThan_DropsLeadingChunks()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 3);
+			// Fill 2 full chunks + 1 partial: logical indices 0, 1, 2
+			for (int i = 0; i < 7; i++)
+				buf.Append(new PingRecord { RelativeTimeMs = (uint)i });
+
+			// Keep chunks with logical index >= 1 (drop chunk 0)
+			buf.PruneChunksOlderThan(1);
+
+			Assert.Equal(2, buf.ChunkCount);
+			Assert.Equal(1, buf.FirstLogicalChunkIndex);
+			Assert.Equal(4, buf.ActiveCount); // 3 from chunk1 + 1 from chunk2
+		}
+
+		[Fact]
+		public void PruneChunksOlderThan_NeverDropsLastChunk()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 3);
+			for (int i = 0; i < 3; i++)
+				buf.Append(new PingRecord { RelativeTimeMs = (uint)i });
+
+			// Request dropping all chunks
+			buf.PruneChunksOlderThan(999);
+
+			Assert.Equal(1, buf.ChunkCount); // last chunk always preserved
+			Assert.Equal(3, buf.ActiveCount);
+		}
+
+		[Fact]
+		public void BinarySearch_LowerBound_FindsCorrectHandle()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 4);
+			uint[] times = { 10, 20, 30, 40, 50, 60 };
+			foreach (uint t in times)
+				buf.Append(new PingRecord { RelativeTimeMs = t });
+
+			var h = buf.LowerBound(r => r.RelativeTimeMs, 30u);
+			Assert.NotNull(h);
+			Assert.Equal(30u, buf.Get(h.Value).RelativeTimeMs);
+		}
+
+		[Fact]
+		public void BinarySearch_LowerBound_FindsFirstGreaterThan()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 4);
+			uint[] times = { 10, 20, 40, 50 };
+			foreach (uint t in times)
+				buf.Append(new PingRecord { RelativeTimeMs = t });
+
+			// Target 30 doesn't exist; should land on 40
+			var h = buf.LowerBound(r => r.RelativeTimeMs, 30u);
+			Assert.NotNull(h);
+			Assert.Equal(40u, buf.Get(h.Value).RelativeTimeMs);
+		}
+
+		[Fact]
+		public void BinarySearch_LowerBound_ReturnsNull_WhenAllLess()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 4);
+			buf.Append(new PingRecord { RelativeTimeMs = 5 });
+			buf.Append(new PingRecord { RelativeTimeMs = 10 });
+
+			var h = buf.LowerBound(r => r.RelativeTimeMs, 100u);
+			Assert.Null(h);
+		}
+
+		[Fact]
+		public void BinarySearch_LowerBound_ReturnsNull_WhenEmpty()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 4);
+			Assert.Null(buf.LowerBound(r => r.RelativeTimeMs, 0u));
+		}
+
+		[Fact]
+		public void BinarySearch_LowerBound_AcrossChunkBoundary()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 3);
+			// chunk 0: 10, 20, 30 | chunk 1: 40, 50, 60 | chunk 2: 70
+			for (uint t = 10; t <= 70; t += 10)
+				buf.Append(new PingRecord { RelativeTimeMs = t });
+
+			var h = buf.LowerBound(r => r.RelativeTimeMs, 45u);
+			Assert.NotNull(h);
+			Assert.Equal(50u, buf.Get(h.Value).RelativeTimeMs);
+		}
+
+		[Fact]
+		public void EnumerateFrom_PrunedHandle_StartFromBeginning()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 3);
+			for (uint i = 0; i < 6; i++)
+				buf.Append(new PingRecord { RelativeTimeMs = i * 10 });
+
+			var staleHandle = new RecordHandle(0, 0); // logical chunk 0
+
+			// Prune chunk 0
+			buf.PruneChunksOlderThan(1);
+
+			// Enumerate from stale handle — should start from first available
+			var list = new System.Collections.Generic.List<uint>();
+			foreach (var (_, r) in buf.EnumerateFrom(staleHandle))
+				list.Add(r.RelativeTimeMs);
+
+			Assert.Equal(new uint[] { 30, 40, 50 }, list);
+		}
+
+		[Fact]
+		public void HandleLogicalIndexStable_AfterPrune()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 3);
+			// Fill chunk 0
+			for (uint i = 0; i < 3; i++)
+				buf.Append(new PingRecord { RelativeTimeMs = i });
+
+			// Append to chunk 1, keep the handle
+			var handle = buf.Append(new PingRecord { RelativeTimeMs = 100, RoundTripMs = 55 });
+
+			// Drop chunk 0
+			buf.PruneChunksOlderThan(1);
+
+			// Handle should still work
+			Assert.Equal((ushort)55, buf.Get(handle).RoundTripMs);
+		}
+
+		[Fact]
+		public void GetRef_PrunedChunk_Throws()
+		{
+			var buf = new ChunkedSeriesBuffer<PingRecord>(chunkSize: 3);
+			for (int i = 0; i < 4; i++)
+				buf.Append(new PingRecord { RelativeTimeMs = (uint)i });
+
+			var stale = new RecordHandle(0, 0);
+			buf.PruneChunksOlderThan(1);
+
+			Assert.Throws<InvalidOperationException>(() => buf.GetRef(stale));
+		}
+	}
+}

--- a/PingTest/PingTracer.Tests/HopTimeSeriesTests.cs
+++ b/PingTest/PingTracer.Tests/HopTimeSeriesTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using PingTracer.Storage;
+using Xunit;
+
+namespace PingTracer.Tests
+{
+	public class HopTimeSeriesTests
+	{
+		private static readonly IPAddress TestAddr = IPAddress.Parse("10.0.0.1");
+		private static readonly DateTime T0 = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+		[Fact]
+		public void BeginPendingRecord_ReturnsPendingRecord()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+			var handle = series.BeginPendingRecord(T0.AddMilliseconds(100));
+
+			var results = new List<(DateTime, ushort)>(series.QueryRange(T0, T0.AddDays(1)));
+			Assert.Single(results);
+			Assert.Equal(PingRecordStatus.Pending, results[0].Item2);
+		}
+
+		[Fact]
+		public void CompleteRecord_UpdatesRttInPlace()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+			var handle = series.BeginPendingRecord(T0.AddMilliseconds(100));
+
+			series.CompleteRecord(handle, 42);
+
+			var results = new List<(DateTime, ushort)>(series.QueryRange(T0, T0.AddDays(1)));
+			Assert.Single(results);
+			Assert.Equal((ushort)42, results[0].Item2);
+		}
+
+		[Fact]
+		public void BackwardClock_SecondRecordClamped()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+
+			var h1 = series.BeginPendingRecord(T0.AddMilliseconds(500));
+			var h2 = series.BeginPendingRecord(T0.AddMilliseconds(200)); // backward
+
+			var results = new List<(DateTime, ushort)>(series.QueryRange(T0, T0.AddDays(1)));
+			Assert.Equal(2, results.Count);
+
+			// Second record should be clamped to T0+500ms, not T0+200ms
+			Assert.True(results[1].Item1 >= results[0].Item1);
+			Assert.Equal(T0.AddMilliseconds(500), results[1].Item1);
+		}
+
+		[Fact]
+		public void OutOfOrderCompletion_AllRecordsComplete()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+
+			var h1 = series.BeginPendingRecord(T0.AddMilliseconds(100));
+			var h2 = series.BeginPendingRecord(T0.AddMilliseconds(200));
+			var h3 = series.BeginPendingRecord(T0.AddMilliseconds(300));
+
+			// Complete in reverse order
+			series.CompleteRecord(h3, 30);
+			series.CompleteRecord(h1, 10);
+			series.CompleteRecord(h2, 20);
+
+			var results = new List<(DateTime, ushort)>(series.QueryRange(T0, T0.AddDays(1)));
+			Assert.Equal(3, results.Count);
+			Assert.Equal((ushort)10, results[0].Item2);
+			Assert.Equal((ushort)20, results[1].Item2);
+			Assert.Equal((ushort)30, results[2].Item2);
+		}
+
+		[Fact]
+		public void QueryRange_ReturnsOnlyRecordsInWindow()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+
+			for (int i = 1; i <= 10; i++)
+			{
+				var h = series.BeginPendingRecord(T0.AddSeconds(i));
+				series.CompleteRecord(h, (ushort)(i * 10));
+			}
+
+			// Query seconds 3-7
+			var results = new List<(DateTime, ushort)>(
+				series.QueryRange(T0.AddSeconds(3), T0.AddSeconds(7)));
+
+			Assert.Equal(5, results.Count);
+			Assert.Equal((ushort)30, results[0].Item2);
+			Assert.Equal((ushort)70, results[4].Item2);
+		}
+
+		[Fact]
+		public void QueryRange_EmptyWhenWindowOutside()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+			var h = series.BeginPendingRecord(T0.AddSeconds(5));
+			series.CompleteRecord(h, 10);
+
+			var before = new List<(DateTime, ushort)>(series.QueryRange(T0.AddSeconds(6), T0.AddSeconds(10)));
+			Assert.Empty(before);
+		}
+
+		[Fact]
+		public void AggregateRange_ReturnsSinglePoints_WhenUnderMaxPoints()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+			for (int i = 1; i <= 5; i++)
+			{
+				var h = series.BeginPendingRecord(T0.AddSeconds(i));
+				series.CompleteRecord(h, (ushort)(i * 10));
+			}
+
+			var result = series.AggregateRange(T0, T0.AddSeconds(10), maxPoints: 100);
+			Assert.Equal(5, result.Points.Length);
+			Assert.Equal(10.0, result.Points[0].AvgRtt);
+		}
+
+		[Fact]
+		public void AggregateRange_Downsamples_WhenOverMaxPoints()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+			for (int i = 1; i <= 100; i++)
+			{
+				var h = series.BeginPendingRecord(T0.AddSeconds(i));
+				series.CompleteRecord(h, (ushort)i);
+			}
+
+			var result = series.AggregateRange(T0, T0.AddSeconds(100), maxPoints: 10);
+			Assert.Equal(10, result.Points.Length);
+
+			// Each bucket should have ~10 samples
+			foreach (var pt in result.Points)
+				Assert.True(pt.SampleCount > 0);
+		}
+
+		[Fact]
+		public void AggregateRange_PendingRecords_ExcludedFromLatency()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+			series.BeginPendingRecord(T0.AddSeconds(1)); // left pending intentionally
+			var h2 = series.BeginPendingRecord(T0.AddSeconds(2));
+			series.CompleteRecord(h2, 50);
+
+			var result = series.AggregateRange(T0, T0.AddSeconds(5), maxPoints: 10);
+			// Only the completed record contributes to AvgRtt
+			var ptWithData = Array.Find(result.Points, p => p.SampleCount > 0 && p.AvgRtt > 0);
+			Assert.True(ptWithData.SampleCount > 0 && ptWithData.AvgRtt > 0, "Expected at least one bucket with completed ping data");
+			Assert.Equal(50.0, ptWithData.AvgRtt);
+		}
+
+		[Fact]
+		public void PruneOlderThan_DropsOldChunks_KeepsRecent()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0, startDnsLookup: false);
+
+			// Insert 5000 records (> 1 chunk of 4096)
+			for (int i = 0; i < 5000; i++)
+			{
+				var h = series.BeginPendingRecord(T0.AddSeconds(i));
+				series.CompleteRecord(h, 10);
+			}
+
+			long before = series.RecordCount;
+			Assert.Equal(5000, before);
+
+			// Prune everything older than T0 + 4097 seconds
+			series.PruneOlderThan(T0.AddSeconds(4097));
+
+			Assert.True(series.RecordCount < before, "Some records should have been pruned");
+
+			// Records after T0+4096s should still be accessible
+			var results = new List<(DateTime, ushort)>(
+				series.QueryRange(T0.AddSeconds(4096), T0.AddSeconds(5000)));
+			Assert.NotEmpty(results);
+		}
+
+		[Fact]
+		public void SetHostname_FiresHostnameUpdatedEvent()
+		{
+			var series = new HopTimeSeries(0, TestAddr, T0);
+			HopTimeSeries fired = null;
+			series.HostnameUpdated += s => fired = s;
+
+			series.SetHostname("router.example.com");
+
+			Assert.Same(series, fired);
+			Assert.Equal("router.example.com", series.Hostname);
+		}
+	}
+}

--- a/PingTest/PingTracer.Tests/MonitoringSessionTests.cs
+++ b/PingTest/PingTracer.Tests/MonitoringSessionTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using PingTracer.Storage;
+using PingTracer.TraceRoute;
+using Xunit;
+
+namespace PingTracer.Tests
+{
+	public class MonitoringSessionTests
+	{
+		private static readonly IPAddress Target = IPAddress.Parse("8.8.8.8");
+		private static readonly DateTime T0 = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+		private static TraceRouteHostResult Hit(byte ttl, string ip, long rtt = 10)
+		{
+			return new TraceRouteHostResult(null, true, rtt, IPAddress.Parse(ip), ttl, Target, ttl, 5000);
+		}
+
+		private static TraceRouteHostResult Miss(byte ttl)
+		{
+			return new TraceRouteHostResult(null, false, 0, IPAddress.Any, ttl, Target, ttl, 5000);
+		}
+
+		[Fact]
+		public void RecordTraceResult_NewHop_CreatesSeriesInHistory()
+		{
+			var session = new MonitoringSession(Target, "test");
+			session.RecordTraceResult(new[] { Hit(1, "192.168.1.1") }, T0);
+
+			var series = session.HopData[0].Series;
+			Assert.Single(series);
+			Assert.Equal(IPAddress.Parse("192.168.1.1"), series[0].Address);
+			Assert.True(series[0].IsActive);
+		}
+
+		[Fact]
+		public void RecordTraceResult_SameHopSameAddress_ReusesActiveSeries()
+		{
+			var session = new MonitoringSession(Target, "test");
+			session.RecordTraceResult(new[] { Hit(1, "192.168.1.1") }, T0);
+			session.RecordTraceResult(new[] { Hit(1, "192.168.1.1") }, T0.AddSeconds(1));
+
+			// Still only one series
+			Assert.Single(session.HopData[0].Series);
+		}
+
+		[Fact]
+		public void RecordTraceResult_AddressChange_CreatesNewSeriesClosesOld()
+		{
+			var session = new MonitoringSession(Target, "test");
+			session.RecordTraceResult(new[] { Hit(1, "192.168.1.1") }, T0);
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0.AddSeconds(1));
+
+			var history = session.HopData[0].Series;
+			Assert.Equal(2, history.Count);
+
+			var old = history[0];
+			var current = history[1];
+
+			Assert.False(old.IsActive);
+			Assert.Equal(T0.AddSeconds(1), old.EndTimeUtc);
+			Assert.True(current.IsActive);
+			Assert.Equal(IPAddress.Parse("10.0.0.1"), current.Address);
+		}
+
+		[Fact]
+		public void RecordTraceResult_AddressRevert_CreatesNewSeries_NoReuse()
+		{
+			var session = new MonitoringSession(Target, "test");
+			session.RecordTraceResult(new[] { Hit(1, "1.1.1.1") }, T0);
+			session.RecordTraceResult(new[] { Hit(1, "2.2.2.2") }, T0.AddSeconds(1));
+			session.RecordTraceResult(new[] { Hit(1, "1.1.1.1") }, T0.AddSeconds(2)); // revert
+
+			var history = session.HopData[0].Series;
+			// All three are distinct entries even though third has same address as first
+			Assert.Equal(3, history.Count);
+			Assert.False(history[0].IsActive);
+			Assert.False(history[1].IsActive);
+			Assert.True(history[2].IsActive);
+		}
+
+		[Fact]
+		public void RecordTraceResult_MissingHop_ClosesActiveSeries()
+		{
+			var session = new MonitoringSession(Target, "test");
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1"), Hit(2, "10.0.0.2") }, T0);
+
+			// Second trace: hop 1 is gone
+			session.RecordTraceResult(new[] { Miss(1), Hit(2, "10.0.0.2") }, T0.AddSeconds(1));
+
+			var h0 = session.HopData[0];
+			Assert.Single(h0.Series);
+			Assert.False(h0.Series[0].IsActive);
+			Assert.Equal(T0.AddSeconds(1), h0.Series[0].EndTimeUtc);
+
+			var h1 = session.HopData[1];
+			Assert.Single(h1.Series);
+			Assert.True(h1.Series[0].IsActive);
+		}
+
+		[Fact]
+		public void RouteChangedEvent_FiredOnAddressChange()
+		{
+			var session = new MonitoringSession(Target, "test");
+			int changeCount = 0;
+			session.RouteChanged += (_, _) => changeCount++;
+
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0);
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0.AddSeconds(1)); // no change
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.2") }, T0.AddSeconds(2)); // change
+
+			Assert.Equal(2, changeCount); // first trace (from null) + address change
+		}
+
+		[Fact]
+		public void TraceResultRecorded_FiredEachTrace()
+		{
+			var session = new MonitoringSession(Target, "test");
+			int fired = 0;
+			session.TraceResultRecorded += _ => fired++;
+
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0);
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0.AddSeconds(1));
+
+			Assert.Equal(2, fired);
+		}
+
+		[Fact]
+		public void GetActiveHops_ReturnsOnlyActiveSeriesPerHop()
+		{
+			var session = new MonitoringSession(Target, "test");
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1"), Hit(2, "10.0.0.2") }, T0);
+
+			var active = new List<HopTimeSeries>(session.GetActiveHops());
+			Assert.Equal(2, active.Count);
+			Assert.All(active, s => Assert.True(s.IsActive));
+		}
+
+		[Fact]
+		public void PruneOlderThan_RemovesOldRouteHistory_RetainsAnchor()
+		{
+			var session = new MonitoringSession(Target, "test");
+
+			// Add several route history entries
+			for (int i = 0; i < 5; i++)
+				session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0.AddMinutes(i));
+
+			// Prune everything older than T0 + 3 minutes
+			// RouteHistory has entries at T0, T0+1m, T0+2m, T0+3m, T0+4m
+			// Entries before T0+3m that predate the cutoff: T0, T0+1m, T0+2m
+			// The last one before cutoff (T0+2m) must be retained as anchor.
+			// So we remove T0 (only), keeping T0+1m as anchor... wait let me re-check.
+			// cutoff = T0 + 3m. entries < cutoff: T0, T0+1m, T0+2m (lastBeforeCutoff index = 2)
+			// We remove [0, lastBeforeCutoff) = [0, 2) = indices 0 and 1
+			// Remaining: T0+2m, T0+3m, T0+4m
+
+			session.PruneOlderThan(TimeSpan.FromMinutes(-3).Negate()); // maxAge = 3 minutes
+
+			// The anchor (last entry before cutoff) must be kept.
+			// After pruning, RouteHistory should have at most 3 entries and the oldest should be T0+2m
+			lock (session) { } // just to ensure memory visibility; RouteHistory access is not locked in reads
+			Assert.True(session.RouteHistory.Count >= 1);
+
+			// The very first remaining entry should be >= T0+2m (anchor preserved)
+			Assert.True(session.RouteHistory[0].TimestampUtc >= T0.AddMinutes(2));
+		}
+
+		[Fact]
+		public void PruneOlderThan_RemovesEmptyInactiveSeries()
+		{
+			var session = new MonitoringSession(Target, "test");
+
+			// Hop 0 active for T0..T0+1s, then gone
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0);
+			session.RecordTraceResult(new[] { Miss(1) }, T0.AddSeconds(1));
+
+			// Hop 0 now has one inactive series with no ping records
+			Assert.Single(session.HopData[0].Series);
+			Assert.False(session.HopData[0].Series[0].IsActive);
+
+			// Pruning with a cutoff past the series should remove it
+			session.PruneOlderThan(TimeSpan.FromSeconds(-10)); // cutoff = now - (-10s) = now + 10s... that's future
+
+			// Use a very small maxAge so the cutoff is effectively "now"
+			// which should include the T0 records
+			// Actually let's just call it directly with sufficient maxAge
+			// The series is empty (no pings were recorded in it for >1 day)
+			// PruneOlderThan with maxAge = 0 would set cutoff = now
+			// T0 is 2025-01-01, so all records predate "now" (2026)
+			session.PruneOlderThan(TimeSpan.FromDays(1));
+
+			// Empty inactive series should be gone
+			Assert.Empty(session.HopData[0].Series);
+		}
+
+		[Fact]
+		public void GetAggregatedData_ReturnsOverlappingSeries()
+		{
+			var session = new MonitoringSession(Target, "test");
+			session.RecordTraceResult(new[] { Hit(1, "10.0.0.1") }, T0);
+
+			var overlapping = new List<HopTimeSeries>(
+				session.GetAggregatedData(T0, T0.AddHours(1), maxPointsPerHop: 100));
+
+			Assert.Single(overlapping);
+		}
+	}
+}

--- a/PingTest/PingTracer.Tests/PingRecordTests.cs
+++ b/PingTest/PingTracer.Tests/PingRecordTests.cs
@@ -1,0 +1,42 @@
+using System.Runtime.CompilerServices;
+using PingTracer.Storage;
+using Xunit;
+
+namespace PingTracer.Tests
+{
+	public class PingRecordTests
+	{
+		[Fact]
+		public void PingRecord_Is6Bytes()
+		{
+			Assert.Equal(6, Unsafe.SizeOf<PingRecord>());
+		}
+
+		[Fact]
+		public void PendingStatusConstant_Is0xFFFE()
+		{
+			Assert.Equal(0xFFFE, PingRecordStatus.Pending);
+		}
+
+		[Fact]
+		public void TimeoutStatusConstant_Is0xFFFF()
+		{
+			Assert.Equal(0xFFFF, PingRecordStatus.Timeout);
+		}
+
+		[Fact]
+		public void IsSuccess_ReturnsTrueForValidRtt()
+		{
+			Assert.True(PingRecordStatus.IsSuccess(0));
+			Assert.True(PingRecordStatus.IsSuccess(100));
+			Assert.True(PingRecordStatus.IsSuccess(65533));
+		}
+
+		[Fact]
+		public void IsSuccess_ReturnsFalseForSentinels()
+		{
+			Assert.False(PingRecordStatus.IsSuccess(PingRecordStatus.Pending));
+			Assert.False(PingRecordStatus.IsSuccess(PingRecordStatus.Timeout));
+		}
+	}
+}

--- a/PingTest/PingTracer.Tests/PingTracer.Tests.csproj
+++ b/PingTest/PingTracer.Tests/PingTracer.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>PingTracer.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Compile Storage/ and TraceRouteHostResult directly so the test project
+       has no dependency on BPUtil, which lives outside the worktree. -->
+  <ItemGroup>
+    <Compile Include="..\PingTest\Storage\*.cs" LinkBase="Storage" />
+    <Compile Include="..\PingTest\TraceRoute\TraceRouteHostResult.cs" LinkBase="TraceRoute" />
+  </ItemGroup>
+
+</Project>

--- a/PingTest/PingTracer.Tests/RouteSnapshotTests.cs
+++ b/PingTest/PingTracer.Tests/RouteSnapshotTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Net;
+using PingTracer.Storage;
+using Xunit;
+
+namespace PingTracer.Tests
+{
+	public class RouteSnapshotTests
+	{
+		private static readonly DateTime T0 = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+		private static HopTimeSeries MakeSeries(string ip)
+		{
+			return new HopTimeSeries(0, IPAddress.Parse(ip), T0, startDnsLookup: false);
+		}
+
+		[Fact]
+		public void DiffFrom_EmptyList_WhenIdentical()
+		{
+			var a = MakeSeries("1.2.3.4");
+			var b = MakeSeries("1.2.3.4");
+
+			var snap1 = new RouteSnapshot(T0, new HopTimeSeries[] { a });
+			var snap2 = new RouteSnapshot(T0.AddSeconds(1), new HopTimeSeries[] { b });
+
+			var diff = snap2.DiffFrom(snap1);
+			Assert.Empty(diff);
+		}
+
+		[Fact]
+		public void DiffFrom_DetectsAddressChange()
+		{
+			var old = MakeSeries("1.2.3.4");
+			var newSeries = MakeSeries("5.6.7.8");
+
+			var snap1 = new RouteSnapshot(T0, new HopTimeSeries[] { old });
+			var snap2 = new RouteSnapshot(T0.AddSeconds(1), new HopTimeSeries[] { newSeries });
+
+			var diff = snap2.DiffFrom(snap1);
+			Assert.Single(diff);
+			Assert.Equal(0, diff[0].HopIndex);
+			Assert.Equal(IPAddress.Parse("1.2.3.4"), diff[0].OldAddress);
+			Assert.Equal(IPAddress.Parse("5.6.7.8"), diff[0].NewAddress);
+		}
+
+		[Fact]
+		public void DiffFrom_DetectsHopAppearing()
+		{
+			// Previous snapshot had no hops; new has one
+			var snap1 = new RouteSnapshot(T0, new HopTimeSeries[0]);
+			var snap2 = new RouteSnapshot(T0.AddSeconds(1), new HopTimeSeries[] { MakeSeries("1.2.3.4") });
+
+			var diff = snap2.DiffFrom(snap1);
+			Assert.Single(diff);
+			Assert.Null(diff[0].OldAddress);
+			Assert.Equal(IPAddress.Parse("1.2.3.4"), diff[0].NewAddress);
+		}
+
+		[Fact]
+		public void DiffFrom_DetectsHopDisappearing()
+		{
+			var snap1 = new RouteSnapshot(T0, new HopTimeSeries[] { MakeSeries("1.2.3.4") });
+			var snap2 = new RouteSnapshot(T0.AddSeconds(1), new HopTimeSeries[] { null });
+
+			var diff = snap2.DiffFrom(snap1);
+			Assert.Single(diff);
+			Assert.Equal(IPAddress.Parse("1.2.3.4"), diff[0].OldAddress);
+			Assert.Null(diff[0].NewAddress);
+		}
+
+		[Fact]
+		public void DiffFrom_NullPrevious_AllHopsAreNew()
+		{
+			var snap = new RouteSnapshot(T0, new HopTimeSeries[]
+			{
+				MakeSeries("1.2.3.4"),
+				null,
+				MakeSeries("9.8.7.6"),
+			});
+
+			var diff = snap.DiffFrom(null);
+			// Two non-null hops should appear as new
+			Assert.Equal(2, diff.Count);
+		}
+
+		[Fact]
+		public void DiffFrom_AddressRevert_DetectedAsChange()
+		{
+			var hop0_v1 = MakeSeries("1.1.1.1");
+			var hop0_v2 = MakeSeries("2.2.2.2");
+			var hop0_v3 = MakeSeries("1.1.1.1"); // same address as v1
+
+			var snap1 = new RouteSnapshot(T0, new[] { hop0_v1 });
+			var snap2 = new RouteSnapshot(T0.AddSeconds(1), new[] { hop0_v2 });
+			var snap3 = new RouteSnapshot(T0.AddSeconds(2), new[] { hop0_v3 });
+
+			// v1 -> v2: change
+			Assert.Single(snap2.DiffFrom(snap1));
+			// v2 -> v3 (back to 1.1.1.1): also a change
+			Assert.Single(snap3.DiffFrom(snap2));
+		}
+
+		[Fact]
+		public void DiffFrom_MultipleHops_OnlyChangedOnesReported()
+		{
+			var snap1 = new RouteSnapshot(T0, new HopTimeSeries[]
+			{
+				MakeSeries("1.1.1.1"),
+				MakeSeries("2.2.2.2"),
+				MakeSeries("3.3.3.3"),
+			});
+			var snap2 = new RouteSnapshot(T0.AddSeconds(1), new HopTimeSeries[]
+			{
+				MakeSeries("1.1.1.1"), // same
+				MakeSeries("9.9.9.9"), // changed
+				MakeSeries("3.3.3.3"), // same
+			});
+
+			var diff = snap2.DiffFrom(snap1);
+			Assert.Single(diff);
+			Assert.Equal(1, diff[0].HopIndex);
+		}
+	}
+}

--- a/PingTest/PingTracer.sln
+++ b/PingTest/PingTracer.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BPUtil", "..\..\BPUtil\BPUtil\BPUtil.csproj", "{0DA2C766-3EBA-F134-ECC0-ADFA9886868F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PingTracer.Tests", "PingTracer.Tests\PingTracer.Tests.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,6 +27,10 @@ Global
 		{0DA2C766-3EBA-F134-ECC0-ADFA9886868F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0DA2C766-3EBA-F134-ECC0-ADFA9886868F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0DA2C766-3EBA-F134-ECC0-ADFA9886868F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Replaces the fixed-size PingLog circular buffer concept with a compact, struct-based time-series storage layer that supports variable retention, route topology history, and efficient range queries.

New files in PingTest/Storage/:
- PingRecord (6-byte struct, 5x smaller than PingLog)
- RecordHandle (stable chunk+slot locator, survives front-pruning)
- ChunkedSeriesBuffer<T> (append-only, O(1) random access, O(log n) binary search, O(1) front-pruning without shifting)
- HopTimeSeries (per hop/IP time series: BeginPendingRecord / CompleteRecord in-place update, QueryRange, AggregateRange, PruneOlderThan, async reverse DNS)
- RouteSnapshot + RouteChange (route topology at a point in time, DiffFrom for change detection)
- HopHistory (per-hop chronological list of HopTimeSeries; closed series never reopened)
- MonitoringSession (top-level container: 255-slot HopHistory array, RecordTraceResult, GetActiveHops, PruneOlderThan, RouteChanged / TraceResultRecorded events)

New PingTracer.Tests xUnit project (47 tests, all passing). Test project compiles Storage/ files directly to avoid BPUtil dependency that doesn't resolve in git worktrees.